### PR TITLE
Seminar3 테스트 코드

### DIFF
--- a/seminar2/build.gradle.kts
+++ b/seminar2/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
 
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    
+    testImplementation("org.mockito.kotlin:mockito-kotlin:3.2.0")
     
 }
 

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/seminar/SeminarQueryCountTest.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/seminar/SeminarQueryCountTest.kt
@@ -1,0 +1,59 @@
+package com.wafflestudio.seminar.core.seminar
+
+import com.wafflestudio.seminar.core.maptable.SeminarUser
+import com.wafflestudio.seminar.core.maptable.SeminarUserRepository
+import com.wafflestudio.seminar.core.seminar.service.SeminarService
+import com.wafflestudio.seminar.core.user.UserTestHelper
+import com.wafflestudio.seminar.core.user.api.request.Role
+import com.wafflestudio.seminar.global.HibernateQueryCounter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import javax.servlet.http.HttpServletRequest
+
+@SpringBootTest
+internal class SeminarQueryCountTest @Autowired constructor(
+    private val seminarService: SeminarService,
+    private val hibernateQueryCounter: HibernateQueryCounter,
+    private val seminarUserRepository: SeminarUserRepository,
+    private val userTestHelper: UserTestHelper,
+    private val seminarTestHelper: SeminarTestHelper,
+) {
+    
+    val httpServletRequest = mock(HttpServletRequest::class.java)
+    
+    @Test
+    @Transactional // 다음 에러 때문에 annotate: failed to lazily initialize a collection of role: com.wafflestudio.seminar.core.seminar.database.SeminarEntity.seminarUser, could not initialize proxy - no Session
+                   // 여기에 annotate 하는 경우 쿼리가 1개 (원래보다도 적게) 나와요, SeminarService.kt의 getQuerySeminar에 annotate하는 하면 3 나오는 것 보니까 N+1 problem은 없어 보입니다
+    fun `여러 세미나 조회 Query Count`() {
+        // given
+        val instructor = userTestHelper.createInstructor("inst@ructor.com")
+        given(httpServletRequest.getAttribute("email")).willReturn("inst@ructor.com")
+        val participants = (0..9).map {
+            userTestHelper.createParticipant("part$it@icipant.com")
+        }
+        
+        val seminar = seminarTestHelper.createSeminar(instructor = instructor)
+        
+        participants.forEach {
+            val seminarUser = seminarUserRepository.save(
+                SeminarUser(seminar, it, Role.Participants)
+            )
+            seminar.seminarUser.add(seminarUser)
+            it.seminarUser.add(seminarUser)
+        }
+        
+        // when
+        val (result, queryCount) = hibernateQueryCounter.count {
+            seminarService.getQuerySeminar(httpServletRequest, "", "")
+        }
+        
+        // then
+        assertThat(result).hasSize(1)
+        assertThat(queryCount).isEqualTo(3)
+    }
+}

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/seminar/SeminarServiceTest.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/seminar/SeminarServiceTest.kt
@@ -1,0 +1,256 @@
+package com.wafflestudio.seminar.core.seminar
+
+import com.wafflestudio.seminar.common.SeminarException
+import com.wafflestudio.seminar.core.maptable.SeminarUser
+import com.wafflestudio.seminar.core.maptable.SeminarUserRepository
+import com.wafflestudio.seminar.core.seminar.api.request.RegisterParticipantRequest
+import com.wafflestudio.seminar.core.seminar.api.request.createSeminarRequest
+import com.wafflestudio.seminar.core.seminar.database.SeminarEntity
+import com.wafflestudio.seminar.core.seminar.database.SeminarRepository
+import com.wafflestudio.seminar.core.seminar.service.SeminarService
+import com.wafflestudio.seminar.core.user.UserTestHelper
+import com.wafflestudio.seminar.core.user.api.request.RegisterSeminarRequest
+import com.wafflestudio.seminar.core.user.api.request.Role
+import com.wafflestudio.seminar.core.user.database.UserRepository
+import com.wafflestudio.seminar.core.user.service.AuthTokenService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.transaction.annotation.Transactional
+import javax.servlet.http.HttpServletRequest
+
+@SpringBootTest
+internal class SeminarServiceTest @Autowired constructor(
+    private val seminarService: SeminarService,
+    private val userTestHelper: UserTestHelper,
+    private val seminarTestHelper: SeminarTestHelper,
+    private val userRepository: UserRepository,
+    private val seminarRepository: SeminarRepository,
+    private val seminarUserRepository: SeminarUserRepository,
+) {
+    @MockBean
+    private lateinit var authTokenService: AuthTokenService
+    
+    private val email = "example@email.com"
+    
+    private val seminarName = "seminarname"
+    
+    private val httpServletRequest = mock(HttpServletRequest::class.java)
+    
+    @BeforeEach
+    fun cleanRepository() {
+        userRepository.deleteAll()
+        seminarRepository.deleteAll()
+    }
+    
+    fun givenDefaultCreatedParticipant() {
+        userTestHelper.createParticipant(email)
+    }
+    
+    fun givenDefaultCreatedInstructor() {
+        userTestHelper.createInstructor(email)
+    }
+    
+    fun givenDefaultCreatedSeminar() {
+        seminarTestHelper.createSeminar(name = seminarName, instructor = userTestHelper.createInstructor(email))
+    }
+    
+    fun givenServletRequestReturnsEmail() {
+        given(httpServletRequest.getAttribute("email")).willReturn(email)
+    }
+    
+    // FIXME: 유저 관련 API는 유저 도메인에 있는 게 더 좋을 것 같습니다!
+    @Test
+    @Transactional
+    fun `진행자가 수강생으로 등록 성공`() {
+        // given
+        val request = RegisterParticipantRequest(null, null)
+        givenServletRequestReturnsEmail()
+        
+        // when
+        val result = seminarService.registerToParticipant(httpServletRequest, request)
+        
+        // then
+        assertThat(result.participant).isNotNull
+    }
+    
+    // FIXME: Internal Server Error 발생, SeminarUserRepository에 저장하지 않아서 그런 것 같습니다!
+    @Test
+    @Transactional
+    fun `세미나 개설 성공`() {
+        // given
+        val seminarName = "seminarname"
+        givenDefaultCreatedInstructor()
+        val request = createSeminarRequest(seminarName, 40, 6, "10:00")
+        givenServletRequestReturnsEmail()
+        
+        // when
+        val result = seminarService.createSeminar(httpServletRequest, request)
+        
+        // then
+        assertThat(result.name).isEqualTo(seminarName)
+        assertThat(seminarRepository.findAll()).hasSize(1)
+        assertThat(result.instructors).hasSize(1)
+    }
+    
+    // TODO: 음수인 경우 에러처리 필요
+    @Test
+    @Transactional
+    fun `세미나 개설 실패 - capacity 혹은 count 값 음수`() {
+        // given
+        givenDefaultCreatedInstructor()
+        val request1 = createSeminarRequest(seminarName, -40, 6, "10:00")
+        val request2 = createSeminarRequest(seminarName, 40, -6, "10:00")
+        givenServletRequestReturnsEmail()
+
+        // when
+        val exception1 = assertThrows<SeminarException> {
+            seminarService.createSeminar(httpServletRequest, request1)
+        }
+        val exception2 = assertThrows<SeminarException> {
+            seminarService.createSeminar(httpServletRequest, request2)
+        }
+
+        // then
+        assertThat(exception1.status).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(exception2.status).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+    
+    @Test
+    @Transactional
+    fun `세미나 개설 실패 - 유효하지 않은 시간 형식`() {
+        // given
+        givenDefaultCreatedInstructor()
+        val request = createSeminarRequest(seminarName, 40, 6, "1000")
+        givenServletRequestReturnsEmail()
+        
+        // when
+        val exception = assertThrows<SeminarException> {
+            seminarService.createSeminar(httpServletRequest, request)
+        }
+        
+        // then
+        assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+    
+    @Test
+    @Transactional
+    fun `세미나 정보 조회 성공`() {
+        // given
+        givenDefaultCreatedSeminar()
+        
+        // when
+        val result = seminarService.getSeminar(httpServletRequest, 1L)
+        
+        // then
+        assertThat(result.name).isEqualTo(seminarName)
+    }
+    
+    @Test
+    @Transactional
+    fun `여러 세미나 정보 조회 성공`() {
+        // given
+        val instructors = (0..9).map {
+            userTestHelper.createInstructor("inst$it@ructor.com")
+        }
+        
+        val seminars1 = (0..6).map {
+            seminarTestHelper.createSeminar(name = "SpringSeminar", instructor = instructors[it])
+        }
+        val seminars2 = (7..9).map {
+            seminarTestHelper.createSeminar(name = "DjangoSeminar", instructor = instructors[it])
+        }
+        
+        // when
+        val result1 = seminarService.getQuerySeminar(httpServletRequest, "", "Spring")
+        val result2 = seminarService.getQuerySeminar(httpServletRequest, "", "Django")
+        val result3 = seminarService.getQuerySeminar(httpServletRequest, "", "Seminar")
+        val result4 = seminarService.getQuerySeminar(httpServletRequest, "earliest", "")
+        
+        // then
+        assertThat(result1).hasSize(7)
+        assertThat(result2).hasSize(3)
+        assertThat(result3).hasSize(10)
+        (0..9).forEach {
+            assertThat(result3[it]).isEqualTo(result4[9 - it])
+        }
+    }
+    
+    // FIXME: 수강생이 수강해도 empty list를 반환
+    // FIXME: 에러 발생, com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: com.wafflestudio.seminar.core.seminar.api.response.CreateSeminarResponse["instructors"]->java.util.ArrayList[0]->com.wafflestudio.seminar.core.user.database.UserEntity$HibernateProxy$6m9fNoL0["hibernateLazyInitializer"])
+    @Test
+    @Transactional
+    fun `세미나 참여하기`() {
+        // given
+        givenDefaultCreatedSeminar()
+        val email2 = "another@email.com"
+        userTestHelper.createParticipant(email2)
+        given(httpServletRequest.getAttribute("email")).willReturn(email2)
+        val request = RegisterSeminarRequest("participants")
+        
+        // when
+        val result = seminarService.registerSeminar(httpServletRequest, 1L, request)
+        
+        // then
+        assertThat(result.name).isEqualTo(seminarName)
+        assertThat(result.participants).isNotNull
+        assertThat(result.participants).hasSize(1)
+    }
+
+    // FIXME: CreateSeminarResponse에서 유저 정보가 파싱되지 않고 user entity raw data로 반환 
+    @Test
+    @Transactional
+    fun `세미나 함께 진행하기`() {
+        // given
+        givenDefaultCreatedSeminar()
+        val email2 = "another@email.com"
+        userTestHelper.createInstructor(email2)
+        given(httpServletRequest.getAttribute("email")).willReturn(email2)
+        val request = RegisterSeminarRequest("instructors")
+
+        // when
+        val result = seminarService.registerSeminar(httpServletRequest, 1L, request)
+
+        // then
+        assertThat(result.name).isEqualTo(seminarName)
+        assertThat(result.instructors).hasSize(2)
+    }
+
+    // FIXME: 에러 발생 java.lang.IllegalStateException: stream has already been operated upon or closed
+    @Test
+    @Transactional
+    fun `세미나 드랍하기`() {
+        // given
+        givenDefaultCreatedSeminar()
+        val email2 = "anothre@email.com"
+        val user = userTestHelper.createParticipant(email2)
+        given(httpServletRequest.getAttribute("email")).willReturn(email2)
+        
+        val participantRequest = RegisterSeminarRequest("participants")
+        seminarService.registerSeminar(httpServletRequest, 1L, participantRequest)
+        
+        // when
+        val result = seminarService.dropSeminar(httpServletRequest, 1L)
+        val exception = assertThrows<SeminarException> {
+            seminarService.registerSeminar(httpServletRequest, 1L, participantRequest)
+        }
+        
+        val seminar = seminarRepository.findByIdOrNull(1L)!!
+        val seminarUser = seminarUserRepository.findByUserAndSeminar(user, seminar)
+        
+        // then
+        assertThat(result.name).isEqualTo(seminarName)
+        assertThat(seminarUser[0].isActive).isEqualTo(false)
+        assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(result.participants).hasSize(1)
+    }
+    
+}

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/seminar/SeminarTestHelper.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/seminar/SeminarTestHelper.kt
@@ -1,0 +1,29 @@
+package com.wafflestudio.seminar.core.seminar
+
+import com.wafflestudio.seminar.core.seminar.database.SeminarEntity
+import com.wafflestudio.seminar.core.seminar.database.SeminarRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+internal class SeminarTestHelper @Autowired constructor(
+    private val seminarRepository: SeminarRepository
+) {
+    fun createSeminar(
+        name: String = "",
+        capacity : Int = 10,
+        count : Int = 1,
+        time : String = "00:00",
+        online : Boolean = true,
+    ): SeminarEntity {
+        return seminarRepository.save(
+            SeminarEntity(
+                name,
+                capacity,
+                count,
+                time,
+                online,
+            )
+        )
+    }
+}

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/seminar/SeminarTestHelper.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/seminar/SeminarTestHelper.kt
@@ -1,13 +1,20 @@
 package com.wafflestudio.seminar.core.seminar
 
+import com.wafflestudio.seminar.core.maptable.SeminarUser
+import com.wafflestudio.seminar.core.maptable.SeminarUserRepository
 import com.wafflestudio.seminar.core.seminar.database.SeminarEntity
 import com.wafflestudio.seminar.core.seminar.database.SeminarRepository
+import com.wafflestudio.seminar.core.user.api.request.Role
+import com.wafflestudio.seminar.core.user.database.UserEntity
+import com.wafflestudio.seminar.core.user.database.UserRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
 internal class SeminarTestHelper @Autowired constructor(
-    private val seminarRepository: SeminarRepository
+    private val userRepository: UserRepository,
+    private val seminarRepository: SeminarRepository,
+    private val seminarUserRepository: SeminarUserRepository,
 ) {
     fun createSeminar(
         name: String = "",
@@ -15,8 +22,9 @@ internal class SeminarTestHelper @Autowired constructor(
         count : Int = 1,
         time : String = "00:00",
         online : Boolean = true,
+        instructor: UserEntity,
     ): SeminarEntity {
-        return seminarRepository.save(
+        val seminar =  seminarRepository.save(
             SeminarEntity(
                 name,
                 capacity,
@@ -25,5 +33,20 @@ internal class SeminarTestHelper @Autowired constructor(
                 online,
             )
         )
+        
+        val seminarUser = seminarUserRepository.save(
+            SeminarUser(
+                seminar,
+                instructor,
+                Role.Instructors
+            )
+        )
+        
+        instructor.seminarUser.add(seminarUser)
+        seminar.seminarUser.add(seminarUser)
+        userRepository.save(instructor)
+        seminarRepository.save(seminar)
+        
+        return seminar
     }
 }

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/user/UserServiceTest.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/user/UserServiceTest.kt
@@ -1,0 +1,184 @@
+package com.wafflestudio.seminar.core.user
+
+import com.wafflestudio.seminar.common.SeminarException
+import com.wafflestudio.seminar.core.user.api.request.EditProfileRequest
+import com.wafflestudio.seminar.core.user.api.request.LoginRequest
+import com.wafflestudio.seminar.core.user.api.request.SignUpRequest
+import com.wafflestudio.seminar.core.user.database.UserRepository
+import com.wafflestudio.seminar.core.user.service.AuthService
+import com.wafflestudio.seminar.core.user.service.AuthToken
+import com.wafflestudio.seminar.core.user.service.AuthTokenService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.BDDMockito.anyString
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.transaction.annotation.Transactional
+import javax.servlet.http.HttpServletRequest
+
+@SpringBootTest
+internal class UserServiceTest @Autowired constructor(
+    private val authService: AuthService,
+    private val userTestHelper: UserTestHelper,
+    private val userRepository: UserRepository,
+) {
+    @MockBean
+    private lateinit var authTokenService: AuthTokenService
+    
+    @BeforeEach
+    fun cleanRepository() {
+        userRepository.deleteAll()
+    }
+    
+    fun givenMockToken() {
+        given(authTokenService.generateTokenByUsername(anyString())).willReturn(AuthToken("AUTH_TOKEN"))
+    }
+    
+    @Test
+    fun `회원가입 성공`() {
+        // given
+        givenMockToken()
+        val email = "example@email.com"
+        val request = SignUpRequest(email, "", "", "PARTICIPANT", null, null, null, null)
+
+        // when
+        val result = authService.signUp(request)
+
+        // then
+        assertThat(result).isEqualTo("AUTH_TOKEN")
+        assertThat(userRepository.findAll()).hasSize(1)
+        assertThat(userRepository.findByEmail(email)).isNotNull
+    }
+
+    @Test
+    fun `회원가입 실패 - 중복 이메일`() {
+        // given
+        val email = "example@email.com"
+        userTestHelper.createParticipant(email, "", "")
+        val request = SignUpRequest(email, "", "", "PARTICIPANT", null, null, null, null)
+
+        // when
+        val exception = assertThrows<SeminarException> {
+            authService.signUp(request)
+        }
+
+        // then
+        assertThat(exception.status).isEqualTo(HttpStatus.CONFLICT)
+    }
+    
+    @Test
+    fun `로그인 성공`() {
+        // given
+        givenMockToken()
+        val email = "example@email.com"
+        val password = "secret"
+        userTestHelper.createParticipant(email, "", password)
+        val request = LoginRequest(email, password)
+        
+        // when
+        val result = authService.login(request)
+        
+        // then
+        assertThat(result).isEqualTo("AUTH_TOKEN")
+    }
+
+    @Test
+    fun `로그인 실패 - 잘못된 비밀번호`() {
+        // given
+        givenMockToken()
+        val email = "example@email.com"
+        val password = "secret"
+        userTestHelper.createParticipant(email, "", password)
+        val request = LoginRequest(email, "")
+
+        // when
+        val exception = assertThrows<SeminarException> {
+            authService.login(request)
+        }
+
+        // then
+        assertThat(exception.status).isEqualTo(HttpStatus.UNAUTHORIZED)
+    }
+    
+    // TODO: 내 정보 조회 구현?
+    
+    @Test
+    @Transactional
+    fun `유저 정보 조회 성공`() {
+        // given
+        val email = "example@email.com"
+        userTestHelper.createParticipant(email, "", "")
+        // FIXME: 사용하지 않는 HttpServletRequest?
+        val httpServletRequest: HttpServletRequest = mock(HttpServletRequest::class.java)
+        
+        // when
+        val result = authService.getProfile(1, httpServletRequest)
+        
+        // then
+        assertThat(result.email).isEqualTo(email)
+    }
+    
+    @Test
+    @Transactional
+    fun `유저 정보 조회 실패 - 존재하지 않는 유저`() {
+        // given
+        val email = "example@email.com"
+        userTestHelper.createParticipant(email, "", "")
+        val httpServletRequest = mock(HttpServletRequest::class.java)
+        
+        // when
+        val exception = assertThrows<SeminarException> {
+            authService.getProfile(2, httpServletRequest)
+        }
+        
+        // then
+        assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+    
+    @Test
+    @Transactional
+    fun `유저 정보 수정 성공`() {
+        // given
+        val email = "example@email.com"
+        userTestHelper.createParticipant(email, "", "")
+        val university = "university"
+        val name = "name"
+        val request = EditProfileRequest(university, "company", 1, name)
+        val httpServletRequest = mock(HttpServletRequest::class.java)
+        given(httpServletRequest.getAttribute("email")).willReturn(email)
+        
+        // when
+        val result = authService.editProfile(httpServletRequest, request)
+        
+        // then
+        assertThat(result.username).isEqualTo(name)
+        assertThat(result.participant).isNotNull
+        assertThat(result.participant!!.university).isEqualTo(university)
+        assertThat(result.instructor).isNull()
+    }
+    
+    @Test
+    @Transactional
+    fun `유저 정보 수정 실패 - year 값이 음수`() {
+        // given
+        val email = "example@email.com"
+        userTestHelper.createInstructor(email, "", "")
+        val request = EditProfileRequest("university", "company", -1, "name")
+        val httpServletRequest = mock(HttpServletRequest::class.java)
+        given(httpServletRequest.getAttribute("email")).willReturn(email)
+
+        // when
+        val exception = assertThrows<SeminarException> {
+            authService.editProfile(httpServletRequest, request)
+        }
+
+        // then
+        assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+}

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/user/UserServiceTest.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/user/UserServiceTest.kt
@@ -133,6 +133,7 @@ internal class UserServiceTest @Autowired constructor(
         assertThat(result.email).isEqualTo(email)
     }
     
+    // TODO: Internal Server Error 발생, Error handling 필요
     @Test
     @Transactional
     fun `유저 정보 조회 실패 - 존재하지 않는 유저`() {

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/user/UserServiceTest.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/user/UserServiceTest.kt
@@ -142,7 +142,7 @@ internal class UserServiceTest @Autowired constructor(
         
         // when
         val exception = assertThrows<SeminarException> {
-            authService.getProfile(2, httpServletRequest)
+            authService.getProfile(0, httpServletRequest)
         }
         
         // then

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/user/UserTestHelper.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/user/UserTestHelper.kt
@@ -1,0 +1,71 @@
+package com.wafflestudio.seminar.core.user
+
+import com.wafflestudio.seminar.core.user.database.UserEntity
+import com.wafflestudio.seminar.core.user.database.UserRepository
+import com.wafflestudio.seminar.core.user.database.profile.InstructorProfileEntity
+import com.wafflestudio.seminar.core.user.database.profile.ParticipantProfileEntity
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+internal class UserTestHelper @Autowired constructor(
+    private val passwordEncoder: PasswordEncoder,
+    private val userRepository: UserRepository,
+) {
+    fun createUser(
+        email: String,
+        username: String = "",
+        password: String = "",
+    ): UserEntity {
+        return userRepository.save(
+            UserEntity(
+                email,
+                username,
+                passwordEncoder.encode(password),
+                null,
+                null,
+                LocalDateTime.now()
+            )
+        )
+    }
+
+    fun createInstructor(
+        email: String,
+        username: String = "",
+        password: String = "",
+        company: String = "",
+        year: Long? = null,
+    ): UserEntity {
+        return userRepository.save(
+            UserEntity(
+                email,
+                username,
+                passwordEncoder.encode(password),
+                InstructorProfileEntity(company, year as Int?),
+                null,
+                LocalDateTime.now()
+            )
+        )
+    }
+
+    fun createParticipant(
+        email: String,
+        username: String = "",
+        password: String = "",
+        university: String = "",
+        isActive: Boolean = true,
+    ): UserEntity {
+        return userRepository.save(
+            UserEntity(
+                email,
+                username,
+                passwordEncoder.encode(password),
+                null,
+                ParticipantProfileEntity(isActive, university),
+                LocalDateTime.now()
+            )
+        )
+    }
+}

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/user/UserTestHelper.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/core/user/UserTestHelper.kt
@@ -21,8 +21,8 @@ internal class UserTestHelper @Autowired constructor(
     ): UserEntity {
         return userRepository.save(
             UserEntity(
-                email,
                 username,
+                email,
                 passwordEncoder.encode(password),
                 null,
                 null,
@@ -40,8 +40,8 @@ internal class UserTestHelper @Autowired constructor(
     ): UserEntity {
         return userRepository.save(
             UserEntity(
-                email,
                 username,
+                email,
                 passwordEncoder.encode(password),
                 InstructorProfileEntity(company, year as Int?),
                 null,
@@ -59,8 +59,8 @@ internal class UserTestHelper @Autowired constructor(
     ): UserEntity {
         return userRepository.save(
             UserEntity(
-                email,
                 username,
+                email,
                 passwordEncoder.encode(password),
                 null,
                 ParticipantProfileEntity(isActive, university),

--- a/seminar2/src/test/kotlin/com/wafflestudio/seminar/global/HibernateQueryCounter.kt
+++ b/seminar2/src/test/kotlin/com/wafflestudio/seminar/global/HibernateQueryCounter.kt
@@ -1,0 +1,73 @@
+package com.wafflestudio.seminar.global
+
+import org.hibernate.EmptyInterceptor
+import org.hibernate.cfg.AvailableSettings
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateSettings
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.orm.hibernate5.SpringBeanContainer
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean
+import javax.sql.DataSource
+
+interface HibernateQueryCounter {
+    fun <K> count(block: () -> K): Result<K>
+
+    data class Result<K>(
+        val value: K,
+        val queryCount: Int,
+    )
+}
+
+class HibernateQueryCounterImpl : EmptyInterceptor(), HibernateQueryCounter {
+    private val isCounting: ThreadLocal<Boolean> = ThreadLocal.withInitial { false }
+    private val queryCount: ThreadLocal<Int> = ThreadLocal.withInitial { 0 }
+
+    override fun onPrepareStatement(sql: String?): String {
+        if (isCounting.get()) {
+            queryCount.set(queryCount.get() + 1)
+        }
+
+        return super.onPrepareStatement(sql)
+    }
+
+    override fun <K> count(block: () -> K): HibernateQueryCounter.Result<K> {
+        isCounting.set(true)
+        queryCount.set(0)
+
+        val result = block()
+
+        isCounting.set(false)
+
+        return HibernateQueryCounter.Result(result, queryCount.get())
+    }
+}
+
+@Configuration
+class HibernateConfig {
+    @Bean
+    fun entityManagerFactory(
+        factory: EntityManagerFactoryBuilder,
+        dataSource: DataSource,
+        jpaProperties: JpaProperties,
+        hibernateProperties: HibernateProperties,
+        beanFactory: ConfigurableListableBeanFactory,
+        customInterceptor: HibernateQueryCounterImpl,
+    ): LocalContainerEntityManagerFactoryBean? {
+        val properties: Map<String, Any> =
+            hibernateProperties.determineHibernateProperties(jpaProperties.properties, HibernateSettings())
+                .also { it["hibernate.ejb.interceptor"] = customInterceptor }
+
+        return factory.dataSource(dataSource)
+            .packages("com.wafflestudio.seminar")
+            .properties(properties)
+            .build()
+            .also { it.jpaPropertyMap[AvailableSettings.BEAN_CONTAINER] = SpringBeanContainer(beanFactory) }
+    }
+
+    @Bean
+    fun customInterceptor() = HibernateQueryCounterImpl()
+}


### PR DESCRIPTION
테스트 하면서 확인한 스펙과 다른 부분들, 발생하는 에러 등을
TODO, FIXME 주석으로 기록해 놓았으니까 참고해주세요!

세미나 생성 기능이 동작하지 않았는데,
코드를 좀 확인해보니까 SeminarUserRepsitory에 해당 maptable을 저장하는 부분이 누락되어서 그런 것 같습니다.

쿼리가 조금이라도 복잡해지는 경우에 대해 test할 때
failed to lazily initialize a collection of role ~ 에러가 나타나서 찾아보니
Transactional annotation을 테스트 코드 붙여줘서 해결이 가능했습니다.
대신 테스트 하고자 하는 (service 레이어의) 함수에 붙여줘도 해결이 되는데,
이렇게 하는게 굳이 다시 entity를 save하지 않아도 되고 유리한 점이 있을 것 같아요.

또, 위와 관련해서, getQuerySeminar() 함수의 쿼리 개수를 확인하는 테스트에 해당 어노테이션을 붙이면
원래 쿼리 개수보다도 적은 1개가 나오는데(slack에 올라왔던 이슈인 것 같아요)
어노테이션을 테스트 코드말고 해당 함수에 붙이면 쿼리 개수 3개가 나오는 것을 보아
N+1 문제는 없는 것 같아 보였습니다.

'seminar의 capacity 혹은 count가 음수이면 안된다'와 같은 request에서의 제약조건을
javax.validation 라이브러리의 constraints와 valid 어노테이션을 이용해 에러처리 할 수 있는데,
이렇게 하면 service 레이어에서 필요한 에러처리가 줄어 들어 service 함수들의 역할 부담을 더 줄일 수 있을 것 같습니다.